### PR TITLE
Detach input/output streams from main.cpp

### DIFF
--- a/FalloutScript.h
+++ b/FalloutScript.h
@@ -11,6 +11,7 @@
 #define FALLOUT_SCRIPT_H
 
 // C++ standard includes
+#include <fstream>
 #include <vector>
 
 // int2ssl includes
@@ -24,7 +25,7 @@
 class CFalloutScript
 {
 public:
-    CFalloutScript();
+    CFalloutScript(std::ifstream& ifstream, std::ofstream& ofstream);
     virtual ~CFalloutScript();
 
 public:
@@ -108,6 +109,9 @@ private:
 private:
     // CMapuint32_tToDefObject
     typedef CMap<uint32_t, uint32_t, CDefObject, CDefObject&> CMapuint32_tToDefObject;
+
+    std::ifstream& m_ifstream;
+    std::ofstream& m_ofstream;
 
     CStartupCode m_StartupCode;
     CProcTable   m_ProcTable;

--- a/FalloutScript.h
+++ b/FalloutScript.h
@@ -11,10 +11,10 @@
 #define FALLOUT_SCRIPT_H
 
 // C++ standard includes
-#include <fstream>
 #include <vector>
 
 // int2ssl includes
+#include "FalloutScriptData.h"
 #include "StartupCode.h"
 #include "ProcTable.h"
 #include "Namespace.h"
@@ -25,7 +25,9 @@
 class CFalloutScript
 {
 public:
-    CFalloutScript(std::ifstream& ifstream, std::ofstream& ofstream);
+    CFalloutScript() = delete;
+
+    CFalloutScript(CFalloutScriptData& config);
     virtual ~CFalloutScript();
 
 public:
@@ -110,8 +112,7 @@ private:
     // CMapuint32_tToDefObject
     typedef CMap<uint32_t, uint32_t, CDefObject, CDefObject&> CMapuint32_tToDefObject;
 
-    std::ifstream& m_ifstream;
-    std::ofstream& m_ofstream;
+    CFalloutScriptData& scriptData;
 
     CStartupCode m_StartupCode;
     CProcTable   m_ProcTable;

--- a/FalloutScriptData.h
+++ b/FalloutScriptData.h
@@ -1,0 +1,23 @@
+/**
+ *
+ * Copyright (c) 2005-2009 Anchorite (TeamX), <anchorite2001@yandex.ru>
+ * Copyright (c) 2014-2015 Nirran, phobos2077
+ * Copyright (c) 2015 alexeevdv <mail@alexeevdv.ru>
+ * Distributed under the GNU GPL v3. For full terms see the file license.txt
+ *
+ */
+
+#pragma once
+
+// C++ standard includes
+#include <fstream>
+
+// int2ssl includes
+
+// Third party includes
+
+struct CFalloutScriptData
+{
+    std::ifstream inputStream;
+    std::ofstream outputStream;
+};

--- a/FalloutScriptDump.cpp
+++ b/FalloutScriptDump.cpp
@@ -17,37 +17,34 @@
 
 // Third party includes
 
-extern std::ifstream g_ifstream;
-extern std::ofstream g_ofstream;
-
 void CFalloutScript::Dump()
 {
-    g_ofstream << "============== Procedures table ==================" << std::endl
+    m_ofstream << "============== Procedures table ==================" << std::endl
                << std::endl;
-    m_ProcTable.Dump();
-    g_ofstream << std::endl;
-    g_ofstream << std::endl;
+    m_ProcTable.Dump(m_ofstream);
+    m_ofstream << std::endl;
+    m_ofstream << std::endl;
 
-    g_ofstream << "============== Namespace ==================" << std::endl;
-    m_Namespace.Dump();
-    g_ofstream << std::endl;
-    g_ofstream << std::endl;
+    m_ofstream << "============== Namespace ==================" << std::endl;
+    m_Namespace.Dump(m_ofstream);
+    m_ofstream << std::endl;
+    m_ofstream << std::endl;
 
-    g_ofstream << "============== Stringspace ==================" << std::endl;
-    m_Stringspace.Dump();
-    g_ofstream << std::endl;
-    g_ofstream << std::endl;
+    m_ofstream << "============== Stringspace ==================" << std::endl;
+    m_Stringspace.Dump(m_ofstream);
+    m_ofstream << std::endl;
+    m_ofstream << std::endl;
 
 
     std::string strOutLine;
     uint16_t wOperator;
     uint32_t ulArgument = 0;
 
-    g_ofstream << "============== Global variables values ==================" << std::endl;
+    m_ofstream << "============== Global variables values ==================" << std::endl;
 
     if (m_GlobalVar.empty())
     {
-        g_ofstream << "Not found" << std::endl;
+        m_ofstream << "Not found" << std::endl;
     }
     else
     {
@@ -60,7 +57,7 @@ void CFalloutScript::Dump()
             {
                 case COpcode::O_STRINGOP:
                 case COpcode::O_INTOP:
-                    g_ofstream <<  format("%d: %s(0x%08x)   // %u (%d)",
+                    m_ofstream <<  format("%d: %s(0x%08x)   // %u (%d)",
                                     i,
                                     m_GlobalVar[i].GetAttributes().m_strMnemonic.c_str(),
                                     ulArgument,
@@ -69,7 +66,7 @@ void CFalloutScript::Dump()
                     break;
 
                 case COpcode::O_FLOATOP:
-                    g_ofstream << format("%d: %s(0x%08x)   // %05f",
+                    m_ofstream << format("%d: %s(0x%08x)   // %05f",
                                     i,
                                     m_GlobalVar[i].GetAttributes().m_strMnemonic.c_str(),
                                     ulArgument,
@@ -78,14 +75,14 @@ void CFalloutScript::Dump()
         }
     }
 
-    g_ofstream << std::endl;
-    g_ofstream << std::endl;
+    m_ofstream << std::endl;
+    m_ofstream << std::endl;
 
-    g_ofstream << "============== Exported variables ==================" << std::endl;
+    m_ofstream << "============== Exported variables ==================" << std::endl;
 
     if (m_ExportedVarValue.empty())
     {
-        g_ofstream << "Not found" << std::endl;
+        m_ofstream << "Not found" << std::endl;
     }
     else
     {
@@ -98,38 +95,38 @@ void CFalloutScript::Dump()
             switch(wOperator)
             {
                 case COpcode::O_STRINGOP:
-                    g_ofstream << format("%s := \"%s\"",
+                    m_ofstream << format("%s := \"%s\"",
                                     m_Namespace[ulNameArgument].c_str(),
                                     m_Stringspace[ulArgument].c_str()) << std::endl;
                     break;
 
                 case COpcode::O_INTOP:
-                    g_ofstream << format("%s := %u (%d)",
+                    m_ofstream << format("%s := %u (%d)",
                                     m_Namespace[ulNameArgument].c_str(),
                                     ulArgument,
                                     ulArgument) << std::endl;
                     break;
 
                 case COpcode::O_FLOATOP:
-                    g_ofstream << format("%s := %05f",
+                    m_ofstream << format("%s := %05f",
                                     m_Namespace[ulNameArgument].c_str(),
                                     *((float*)(&ulArgument))) << std::endl;
             }
         }
     }
 
-    g_ofstream << std::endl;
-    g_ofstream << std::endl;
+    m_ofstream << std::endl;
+    m_ofstream << std::endl;
 
-    g_ofstream << "============== Procedures ==================" << std::endl;
-    g_ofstream << std::endl;
+    m_ofstream << "============== Procedures ==================" << std::endl;
+    m_ofstream << std::endl;
 
     for(uint32_t nIndexOfProc = 0; nIndexOfProc < m_ProcTable.GetSize(); nIndexOfProc++)
     {
-        g_ofstream << format("%d: %s (0x%08x)", nIndexOfProc,
+        m_ofstream << format("%d: %s (0x%08x)", nIndexOfProc,
                                                m_Namespace[m_ProcTable[nIndexOfProc].m_ulNameOffset].c_str(),
                                                m_ProcTable[nIndexOfProc].m_ulBodyOffset) << std::endl;
-        g_ofstream << "===============================" << std::endl;
+        m_ofstream << "===============================" << std::endl;
 
         for(uint32_t i = 0; i < m_ProcBodies[nIndexOfProc].size(); i++)
         {
@@ -140,7 +137,7 @@ void CFalloutScript::Dump()
             {
                 case COpcode::O_STRINGOP:
                 case COpcode::O_INTOP:
-                    g_ofstream << format("0x%08X: 0x%04X 0x%08x - %s(0x%08x)   // %u (%d)",
+                    m_ofstream << format("0x%08X: 0x%04X 0x%08x - %s(0x%08x)   // %u (%d)",
                                       m_ProcBodies[nIndexOfProc][i].m_ulOffset,
                                       wOperator,
                                       ulArgument,
@@ -151,7 +148,7 @@ void CFalloutScript::Dump()
                     break;
 
                 case COpcode::O_FLOATOP:
-                    g_ofstream << format("0x%08X: 0x%04X 0x%08X - %s // %05f",
+                    m_ofstream << format("0x%08X: 0x%04X 0x%08X - %s // %05f",
                                       m_ProcBodies[nIndexOfProc][i].m_ulOffset,
                                       wOperator,
                                       ulArgument,
@@ -160,13 +157,13 @@ void CFalloutScript::Dump()
                     break;
 
                 default:
-                    g_ofstream << format("0x%08X: 0x%04X            - %s",
+                    m_ofstream << format("0x%08X: 0x%04X            - %s",
                                       m_ProcBodies[nIndexOfProc][i].m_ulOffset,
                                       wOperator, 
                                       m_ProcBodies[nIndexOfProc][i].m_Opcode.GetAttributes().m_strMnemonic.c_str()) << std::endl;
             }
         }
 
-        g_ofstream << std::endl;
+        m_ofstream << std::endl;
     }
 }

--- a/FalloutScriptDump.cpp
+++ b/FalloutScriptDump.cpp
@@ -19,32 +19,32 @@
 
 void CFalloutScript::Dump()
 {
-    m_ofstream << "============== Procedures table ==================" << std::endl
+    scriptData.outputStream << "============== Procedures table ==================" << std::endl
                << std::endl;
-    m_ProcTable.Dump(m_ofstream);
-    m_ofstream << std::endl;
-    m_ofstream << std::endl;
+    m_ProcTable.Dump(scriptData);
+    scriptData.outputStream << std::endl;
+    scriptData.outputStream << std::endl;
 
-    m_ofstream << "============== Namespace ==================" << std::endl;
-    m_Namespace.Dump(m_ofstream);
-    m_ofstream << std::endl;
-    m_ofstream << std::endl;
+    scriptData.outputStream << "============== Namespace ==================" << std::endl;
+    m_Namespace.Dump(scriptData);
+    scriptData.outputStream << std::endl;
+    scriptData.outputStream << std::endl;
 
-    m_ofstream << "============== Stringspace ==================" << std::endl;
-    m_Stringspace.Dump(m_ofstream);
-    m_ofstream << std::endl;
-    m_ofstream << std::endl;
+    scriptData.outputStream << "============== Stringspace ==================" << std::endl;
+    m_Stringspace.Dump(scriptData);
+    scriptData.outputStream << std::endl;
+    scriptData.outputStream << std::endl;
 
 
     std::string strOutLine;
     uint16_t wOperator;
     uint32_t ulArgument = 0;
 
-    m_ofstream << "============== Global variables values ==================" << std::endl;
+    scriptData.outputStream << "============== Global variables values ==================" << std::endl;
 
     if (m_GlobalVar.empty())
     {
-        m_ofstream << "Not found" << std::endl;
+        scriptData.outputStream << "Not found" << std::endl;
     }
     else
     {
@@ -57,7 +57,7 @@ void CFalloutScript::Dump()
             {
                 case COpcode::O_STRINGOP:
                 case COpcode::O_INTOP:
-                    m_ofstream <<  format("%d: %s(0x%08x)   // %u (%d)",
+                    scriptData.outputStream <<  format("%d: %s(0x%08x)   // %u (%d)",
                                     i,
                                     m_GlobalVar[i].GetAttributes().m_strMnemonic.c_str(),
                                     ulArgument,
@@ -66,7 +66,7 @@ void CFalloutScript::Dump()
                     break;
 
                 case COpcode::O_FLOATOP:
-                    m_ofstream << format("%d: %s(0x%08x)   // %05f",
+                    scriptData.outputStream << format("%d: %s(0x%08x)   // %05f",
                                     i,
                                     m_GlobalVar[i].GetAttributes().m_strMnemonic.c_str(),
                                     ulArgument,
@@ -75,14 +75,14 @@ void CFalloutScript::Dump()
         }
     }
 
-    m_ofstream << std::endl;
-    m_ofstream << std::endl;
+    scriptData.outputStream << std::endl;
+    scriptData.outputStream << std::endl;
 
-    m_ofstream << "============== Exported variables ==================" << std::endl;
+    scriptData.outputStream << "============== Exported variables ==================" << std::endl;
 
     if (m_ExportedVarValue.empty())
     {
-        m_ofstream << "Not found" << std::endl;
+        scriptData.outputStream << "Not found" << std::endl;
     }
     else
     {
@@ -95,38 +95,38 @@ void CFalloutScript::Dump()
             switch(wOperator)
             {
                 case COpcode::O_STRINGOP:
-                    m_ofstream << format("%s := \"%s\"",
+                    scriptData.outputStream << format("%s := \"%s\"",
                                     m_Namespace[ulNameArgument].c_str(),
                                     m_Stringspace[ulArgument].c_str()) << std::endl;
                     break;
 
                 case COpcode::O_INTOP:
-                    m_ofstream << format("%s := %u (%d)",
+                    scriptData.outputStream << format("%s := %u (%d)",
                                     m_Namespace[ulNameArgument].c_str(),
                                     ulArgument,
                                     ulArgument) << std::endl;
                     break;
 
                 case COpcode::O_FLOATOP:
-                    m_ofstream << format("%s := %05f",
+                    scriptData.outputStream << format("%s := %05f",
                                     m_Namespace[ulNameArgument].c_str(),
                                     *((float*)(&ulArgument))) << std::endl;
             }
         }
     }
 
-    m_ofstream << std::endl;
-    m_ofstream << std::endl;
+    scriptData.outputStream << std::endl;
+    scriptData.outputStream << std::endl;
 
-    m_ofstream << "============== Procedures ==================" << std::endl;
-    m_ofstream << std::endl;
+    scriptData.outputStream << "============== Procedures ==================" << std::endl;
+    scriptData.outputStream << std::endl;
 
     for(uint32_t nIndexOfProc = 0; nIndexOfProc < m_ProcTable.GetSize(); nIndexOfProc++)
     {
-        m_ofstream << format("%d: %s (0x%08x)", nIndexOfProc,
+        scriptData.outputStream << format("%d: %s (0x%08x)", nIndexOfProc,
                                                m_Namespace[m_ProcTable[nIndexOfProc].m_ulNameOffset].c_str(),
                                                m_ProcTable[nIndexOfProc].m_ulBodyOffset) << std::endl;
-        m_ofstream << "===============================" << std::endl;
+        scriptData.outputStream << "===============================" << std::endl;
 
         for(uint32_t i = 0; i < m_ProcBodies[nIndexOfProc].size(); i++)
         {
@@ -137,7 +137,7 @@ void CFalloutScript::Dump()
             {
                 case COpcode::O_STRINGOP:
                 case COpcode::O_INTOP:
-                    m_ofstream << format("0x%08X: 0x%04X 0x%08x - %s(0x%08x)   // %u (%d)",
+                    scriptData.outputStream << format("0x%08X: 0x%04X 0x%08x - %s(0x%08x)   // %u (%d)",
                                       m_ProcBodies[nIndexOfProc][i].m_ulOffset,
                                       wOperator,
                                       ulArgument,
@@ -148,7 +148,7 @@ void CFalloutScript::Dump()
                     break;
 
                 case COpcode::O_FLOATOP:
-                    m_ofstream << format("0x%08X: 0x%04X 0x%08X - %s // %05f",
+                    scriptData.outputStream << format("0x%08X: 0x%04X 0x%08X - %s // %05f",
                                       m_ProcBodies[nIndexOfProc][i].m_ulOffset,
                                       wOperator,
                                       ulArgument,
@@ -157,13 +157,13 @@ void CFalloutScript::Dump()
                     break;
 
                 default:
-                    m_ofstream << format("0x%08X: 0x%04X            - %s",
+                    scriptData.outputStream << format("0x%08X: 0x%04X            - %s",
                                       m_ProcBodies[nIndexOfProc][i].m_ulOffset,
                                       wOperator, 
                                       m_ProcBodies[nIndexOfProc][i].m_Opcode.GetAttributes().m_strMnemonic.c_str()) << std::endl;
             }
         }
 
-        m_ofstream << std::endl;
+        scriptData.outputStream << std::endl;
     }
 }

--- a/FalloutScriptStore.cpp
+++ b/FalloutScriptStore.cpp
@@ -24,37 +24,37 @@ void CFalloutScript::StoreTree()
 {
     std::string strOutLine;
 
-    m_ofstream << "============== Procedures ==================" << std::endl;
-    m_ofstream << std::endl;
+    scriptData.outputStream << "============== Procedures ==================" << std::endl;
+    scriptData.outputStream << std::endl;
 
     for(uint32_t nIndexOfProc = 0; nIndexOfProc < m_ProcTable.GetSize(); nIndexOfProc++)
     {
-        m_ofstream << format("%d: %s (0x%08x)", nIndexOfProc, m_Namespace[m_ProcTable[nIndexOfProc].m_ulNameOffset].c_str(), m_ProcTable[nIndexOfProc].m_ulBodyOffset) << std::endl;
-        m_ofstream << "===============================" << std::endl;
+        scriptData.outputStream << format("%d: %s (0x%08x)", nIndexOfProc, m_Namespace[m_ProcTable[nIndexOfProc].m_ulNameOffset].c_str(), m_ProcTable[nIndexOfProc].m_ulBodyOffset) << std::endl;
+        scriptData.outputStream << "===============================" << std::endl;
 
         if (m_ProcTable[nIndexOfProc].m_ulType & P_CONDITIONAL)
         {
-            m_ofstream << "Condition" << std::endl;
-            m_ofstream << "===============================" << std::endl;
+            scriptData.outputStream << "Condition" << std::endl;
+            scriptData.outputStream << "===============================" << std::endl;
 
             for(uint32_t i = 0; i < m_Conditions[nIndexOfProc].size(); i++)
             {
-                m_ofstream << format("0x%08X: ", m_Conditions[nIndexOfProc][i].m_ulOffset) << std::endl;
-                m_Conditions[nIndexOfProc][i].StoreTree(m_ofstream, 0, 0);
+                scriptData.outputStream << format("0x%08X: ", m_Conditions[nIndexOfProc][i].m_ulOffset) << std::endl;
+                m_Conditions[nIndexOfProc][i].StoreTree(scriptData, 0, 0);
             }
 
-            m_ofstream << std::endl;
-            m_ofstream << "Body" << std::endl;
-            m_ofstream << "===============================" << std::endl;
+            scriptData.outputStream << std::endl;
+            scriptData.outputStream << "Body" << std::endl;
+            scriptData.outputStream << "===============================" << std::endl;
         }
 
         for(uint32_t i = 0; i < m_ProcBodies[nIndexOfProc].size(); i++)
         {
-            m_ofstream << format("0x%08X: ", m_ProcBodies[nIndexOfProc][i].m_ulOffset) << std::endl;
-            m_ProcBodies[nIndexOfProc][i].StoreTree(m_ofstream, 0, 0);
+            scriptData.outputStream << format("0x%08X: ", m_ProcBodies[nIndexOfProc][i].m_ulOffset) << std::endl;
+            m_ProcBodies[nIndexOfProc][i].StoreTree(scriptData, 0, 0);
         }
 
-        m_ofstream << std::endl;
+        scriptData.outputStream << std::endl;
     }
 
 }
@@ -62,8 +62,8 @@ void CFalloutScript::StoreTree()
 void CFalloutScript::StoreSource()
 {
     StoreDefinitions();
-    m_ofstream << std::endl;
-    m_ofstream << std::endl;
+    scriptData.outputStream << std::endl;
+    scriptData.outputStream << std::endl;
     StoreDeclarations();
 }
 
@@ -82,7 +82,7 @@ void CFalloutScript::StoreDefinitions()
 
     if (nNamesCount != nDefinitionsCount)
     {
-        m_ofstream << "/*******************************************************" << std::endl
+        scriptData.outputStream << "/*******************************************************" << std::endl
                    << "*      Some unreferenced imported varables found.      *" << std::endl
                    << "*      Because of it it is impossible to specify       *" << std::endl
                    << "*      the real names of global variables.             *" << std::endl
@@ -120,10 +120,10 @@ void CFalloutScript::StoreDefinitions()
                 strDefinition = format(strDefinition + " /* (%d) */", ulVarValue);
             }
 
-            m_ofstream << strDefinition << std::endl;
+            scriptData.outputStream << strDefinition << std::endl;
         }
 
-        m_ofstream << std::endl;
+        scriptData.outputStream << std::endl;
     }
 
 
@@ -272,11 +272,11 @@ void CFalloutScript::StoreDefinitions()
 
         if ((currentOut != lastOut) && (lastOut != OUT_NOTHING))
         {
-            m_ofstream << std::endl;
+            scriptData.outputStream << std::endl;
         }
 
         lastOut = currentOut;
-        m_ofstream << strDefinition << std::endl;
+        scriptData.outputStream << strDefinition << std::endl;
     }
 }
 
@@ -303,7 +303,7 @@ void CFalloutScript::StoreDeclarations()
         // Empty procedure
         if (m_ProcTable.GetSizeOfProc(i) == 0)
         {
-            m_ofstream << "/*******************************************************" << std::endl
+            scriptData.outputStream << "/*******************************************************" << std::endl
                        << "*    Found Procedure without body.                     *" << std::endl
                        << "*                                                      *" << std::endl;
             strOutLine = "*    Name: ";
@@ -315,12 +315,12 @@ void CFalloutScript::StoreDeclarations()
             }
 
             strOutLine += "*";
-            m_ofstream << strOutLine << std::endl
+            scriptData.outputStream << strOutLine << std::endl
                        << "*                                                      *" << std::endl;
 
             if (!(m_ProcTable[i].m_ulType & P_NOTIMPLEMENTED))
             {
-                m_ofstream << "*    Other possible name(s):                           *" << std::endl;
+                scriptData.outputStream << "*    Other possible name(s):                           *" << std::endl;
 
                 for(uint32_t j = i + 1; j < m_ProcTable.GetSize(); j++)
                 {
@@ -335,17 +335,17 @@ void CFalloutScript::StoreDeclarations()
                         }
 
                         strOutLine += "*";
-                        m_ofstream << strOutLine << std::endl;
+                        scriptData.outputStream << strOutLine << std::endl;
                         strOutLine = "*       ";
                     }
                 }
             }
             else
             {
-                m_ofstream << "*           Not implemented                            *" << std::endl;
+                scriptData.outputStream << "*           Not implemented                            *" << std::endl;
             }
 
-            m_ofstream << "*                                                      *" << std::endl
+            scriptData.outputStream << "*                                                      *" << std::endl
                        << "*******************************************************/" << std::endl
                        << std::endl;
             continue;
@@ -394,7 +394,7 @@ void CFalloutScript::StoreDeclarations()
             strOutLine = format(strOutLine + " when (%s)", GetSource(m_Conditions[i][0], false, procDescriptor.m_ulNumArgs).c_str());
         }
 
-        m_ofstream << strOutLine << std::endl;
+        scriptData.outputStream << strOutLine << std::endl;
 
         bool bLocalVar = true;
         uint32_t ulLocalVarIndex = procDescriptor.m_ulNumArgs;
@@ -407,12 +407,12 @@ void CFalloutScript::StoreDeclarations()
             {
                 if ((nNodeIndex > 1) && (m_ProcBodies[i][nNodeIndex - 1].m_Type == CNode::TYPE_END_OF_BLOCK))
                 {
-                    m_ofstream << GetIndentString(nIndentLevel) << "else begin" << std::endl;
+                    scriptData.outputStream << GetIndentString(nIndentLevel) << "else begin" << std::endl;
                     nIndentLevel++;
-                }              
+                }
                 else
                 {
-                    m_ofstream << "begin" << std::endl;
+                    scriptData.outputStream << "begin" << std::endl;
                     nIndentLevel++;
                 }
                 //prevNodeType = CNode::TYPE_BEGIN_OF_BLOCK;
@@ -420,7 +420,7 @@ void CFalloutScript::StoreDeclarations()
             else if (m_ProcBodies[i][nNodeIndex].m_Type == CNode::TYPE_END_OF_BLOCK)
             {
                 nIndentLevel--;
-                m_ofstream << GetIndentString(nIndentLevel) << "end" << std::endl;
+                scriptData.outputStream << GetIndentString(nIndentLevel) << "end" << std::endl;
                 //prevNodeType = CNode::TYPE_END_OF_BLOCK;
             }
             else
@@ -449,12 +449,12 @@ void CFalloutScript::StoreDeclarations()
                         str += c_strLocalVarTemplate + " := ";
 
                         strOutLine = format(str.c_str(), ulLocalVarIndex);
-                        m_ofstream << GetIndentString(nIndentLevel) << strOutLine << GetSource(m_ProcBodies[i][nNodeIndex], false, procDescriptor.m_ulNumArgs) <<  ";" << std::endl;
+                        scriptData.outputStream << GetIndentString(nIndentLevel) << strOutLine << GetSource(m_ProcBodies[i][nNodeIndex], false, procDescriptor.m_ulNumArgs) <<  ";" << std::endl;
                         ulLocalVarIndex++;
                         break;
                     }
                     case COpcode::O_IF:
-                        m_ofstream << GetIndentString(nIndentLevel) << GetSource(m_ProcBodies[i][nNodeIndex], false, procDescriptor.m_ulNumArgs) << " then ";
+                        scriptData.outputStream << GetIndentString(nIndentLevel) << GetSource(m_ProcBodies[i][nNodeIndex], false, procDescriptor.m_ulNumArgs) << " then ";
                         break;
 
                     case COpcode::O_WHILE:
@@ -470,16 +470,16 @@ void CFalloutScript::StoreDeclarations()
                                 str += GetSource(m_ProcBodies[i][nNodeIndex].m_Arguments[j], false, procDescriptor.m_ulNumArgs);
                             }
                             str += ") ";
-                            m_ofstream << str;
+                            scriptData.outputStream << str;
                         }
                         else
                         {
-                            m_ofstream << GetIndentString(nIndentLevel) << GetSource(m_ProcBodies[i][nNodeIndex], false, procDescriptor.m_ulNumArgs) << " do ";
+                            scriptData.outputStream << GetIndentString(nIndentLevel) << GetSource(m_ProcBodies[i][nNodeIndex], false, procDescriptor.m_ulNumArgs) << " do ";
                         }
                         break;
 
                     default:
-                        m_ofstream << GetIndentString(nIndentLevel) << GetSource(m_ProcBodies[i][nNodeIndex], false, procDescriptor.m_ulNumArgs) << ";" << std::endl;
+                        scriptData.outputStream << GetIndentString(nIndentLevel) << GetSource(m_ProcBodies[i][nNodeIndex], false, procDescriptor.m_ulNumArgs) << ";" << std::endl;
 
                         if ((m_ProcBodies[i][nNodeIndex].m_Type != CNode::TYPE_BEGIN_OF_BLOCK) &&
                             (m_ProcBodies[i][nNodeIndex].m_Type != CNode::TYPE_END_OF_BLOCK))
@@ -490,7 +490,7 @@ void CFalloutScript::StoreDeclarations()
             }
         }
 
-        m_ofstream << std::endl;
+        scriptData.outputStream << std::endl;
     }
 }
 

--- a/FalloutScriptStore.cpp
+++ b/FalloutScriptStore.cpp
@@ -19,44 +19,42 @@
 // Third party includes
 
 extern std::string g_strIndentFill;
-extern std::ofstream g_ifstream;
-extern std::ofstream g_ofstream;
 
 void CFalloutScript::StoreTree()
 {
     std::string strOutLine;
 
-    g_ofstream << "============== Procedures ==================" << std::endl;
-    g_ofstream << std::endl;
+    m_ofstream << "============== Procedures ==================" << std::endl;
+    m_ofstream << std::endl;
 
     for(uint32_t nIndexOfProc = 0; nIndexOfProc < m_ProcTable.GetSize(); nIndexOfProc++)
     {
-        g_ofstream << format("%d: %s (0x%08x)", nIndexOfProc, m_Namespace[m_ProcTable[nIndexOfProc].m_ulNameOffset].c_str(), m_ProcTable[nIndexOfProc].m_ulBodyOffset) << std::endl;
-        g_ofstream << "===============================" << std::endl;
+        m_ofstream << format("%d: %s (0x%08x)", nIndexOfProc, m_Namespace[m_ProcTable[nIndexOfProc].m_ulNameOffset].c_str(), m_ProcTable[nIndexOfProc].m_ulBodyOffset) << std::endl;
+        m_ofstream << "===============================" << std::endl;
 
         if (m_ProcTable[nIndexOfProc].m_ulType & P_CONDITIONAL)
         {
-            g_ofstream << "Condition" << std::endl;
-            g_ofstream << "===============================" << std::endl;
+            m_ofstream << "Condition" << std::endl;
+            m_ofstream << "===============================" << std::endl;
 
             for(uint32_t i = 0; i < m_Conditions[nIndexOfProc].size(); i++)
             {
-                g_ofstream << format("0x%08X: ", m_Conditions[nIndexOfProc][i].m_ulOffset) << std::endl;
-                m_Conditions[nIndexOfProc][i].StoreTree(0, 0);
+                m_ofstream << format("0x%08X: ", m_Conditions[nIndexOfProc][i].m_ulOffset) << std::endl;
+                m_Conditions[nIndexOfProc][i].StoreTree(m_ofstream, 0, 0);
             }
 
-            g_ofstream << std::endl;
-            g_ofstream << "Body" << std::endl;
-            g_ofstream << "===============================" << std::endl;
+            m_ofstream << std::endl;
+            m_ofstream << "Body" << std::endl;
+            m_ofstream << "===============================" << std::endl;
         }
 
         for(uint32_t i = 0; i < m_ProcBodies[nIndexOfProc].size(); i++)
         {
-            g_ofstream << format("0x%08X: ", m_ProcBodies[nIndexOfProc][i].m_ulOffset) << std::endl;
-            m_ProcBodies[nIndexOfProc][i].StoreTree(0, 0);
+            m_ofstream << format("0x%08X: ", m_ProcBodies[nIndexOfProc][i].m_ulOffset) << std::endl;
+            m_ProcBodies[nIndexOfProc][i].StoreTree(m_ofstream, 0, 0);
         }
 
-        g_ofstream << std::endl;
+        m_ofstream << std::endl;
     }
 
 }
@@ -64,8 +62,8 @@ void CFalloutScript::StoreTree()
 void CFalloutScript::StoreSource()
 {
     StoreDefinitions();
-    g_ofstream << std::endl;
-    g_ofstream << std::endl;
+    m_ofstream << std::endl;
+    m_ofstream << std::endl;
     StoreDeclarations();
 }
 
@@ -84,7 +82,7 @@ void CFalloutScript::StoreDefinitions()
 
     if (nNamesCount != nDefinitionsCount)
     {
-        g_ofstream << "/*******************************************************" << std::endl
+        m_ofstream << "/*******************************************************" << std::endl
                    << "*      Some unreferenced imported varables found.      *" << std::endl
                    << "*      Because of it it is impossible to specify       *" << std::endl
                    << "*      the real names of global variables.             *" << std::endl
@@ -122,10 +120,10 @@ void CFalloutScript::StoreDefinitions()
                 strDefinition = format(strDefinition + " /* (%d) */", ulVarValue);
             }
 
-            g_ofstream << strDefinition << std::endl;
+            m_ofstream << strDefinition << std::endl;
         }
 
-        g_ofstream << std::endl;
+        m_ofstream << std::endl;
     }
 
 
@@ -274,11 +272,11 @@ void CFalloutScript::StoreDefinitions()
 
         if ((currentOut != lastOut) && (lastOut != OUT_NOTHING))
         {
-            g_ofstream << std::endl;
+            m_ofstream << std::endl;
         }
 
         lastOut = currentOut;
-        g_ofstream << strDefinition << std::endl;
+        m_ofstream << strDefinition << std::endl;
     }
 }
 
@@ -305,7 +303,7 @@ void CFalloutScript::StoreDeclarations()
         // Empty procedure
         if (m_ProcTable.GetSizeOfProc(i) == 0)
         {
-            g_ofstream << "/*******************************************************" << std::endl
+            m_ofstream << "/*******************************************************" << std::endl
                        << "*    Found Procedure without body.                     *" << std::endl
                        << "*                                                      *" << std::endl;
             strOutLine = "*    Name: ";
@@ -317,12 +315,12 @@ void CFalloutScript::StoreDeclarations()
             }
 
             strOutLine += "*";
-            g_ofstream << strOutLine << std::endl
+            m_ofstream << strOutLine << std::endl
                        << "*                                                      *" << std::endl;
 
             if (!(m_ProcTable[i].m_ulType & P_NOTIMPLEMENTED))
             {
-                g_ofstream << "*    Other possible name(s):                           *" << std::endl;
+                m_ofstream << "*    Other possible name(s):                           *" << std::endl;
 
                 for(uint32_t j = i + 1; j < m_ProcTable.GetSize(); j++)
                 {
@@ -337,17 +335,17 @@ void CFalloutScript::StoreDeclarations()
                         }
 
                         strOutLine += "*";
-                        g_ofstream << strOutLine << std::endl;
+                        m_ofstream << strOutLine << std::endl;
                         strOutLine = "*       ";
                     }
                 }
             }
             else
             {
-                g_ofstream << "*           Not implemented                            *" << std::endl;
+                m_ofstream << "*           Not implemented                            *" << std::endl;
             }
 
-            g_ofstream << "*                                                      *" << std::endl
+            m_ofstream << "*                                                      *" << std::endl
                        << "*******************************************************/" << std::endl
                        << std::endl;
             continue;
@@ -396,7 +394,7 @@ void CFalloutScript::StoreDeclarations()
             strOutLine = format(strOutLine + " when (%s)", GetSource(m_Conditions[i][0], false, procDescriptor.m_ulNumArgs).c_str());
         }
 
-        g_ofstream << strOutLine << std::endl;
+        m_ofstream << strOutLine << std::endl;
 
         bool bLocalVar = true;
         uint32_t ulLocalVarIndex = procDescriptor.m_ulNumArgs;
@@ -409,12 +407,12 @@ void CFalloutScript::StoreDeclarations()
             {
                 if ((nNodeIndex > 1) && (m_ProcBodies[i][nNodeIndex - 1].m_Type == CNode::TYPE_END_OF_BLOCK))
                 {
-                    g_ofstream << GetIndentString(nIndentLevel) << "else begin" << std::endl;
+                    m_ofstream << GetIndentString(nIndentLevel) << "else begin" << std::endl;
                     nIndentLevel++;
                 }              
                 else
                 {
-                    g_ofstream << "begin" << std::endl;
+                    m_ofstream << "begin" << std::endl;
                     nIndentLevel++;
                 }
                 //prevNodeType = CNode::TYPE_BEGIN_OF_BLOCK;
@@ -422,7 +420,7 @@ void CFalloutScript::StoreDeclarations()
             else if (m_ProcBodies[i][nNodeIndex].m_Type == CNode::TYPE_END_OF_BLOCK)
             {
                 nIndentLevel--;
-                g_ofstream << GetIndentString(nIndentLevel) << "end" << std::endl;
+                m_ofstream << GetIndentString(nIndentLevel) << "end" << std::endl;
                 //prevNodeType = CNode::TYPE_END_OF_BLOCK;
             }
             else
@@ -451,12 +449,12 @@ void CFalloutScript::StoreDeclarations()
                         str += c_strLocalVarTemplate + " := ";
 
                         strOutLine = format(str.c_str(), ulLocalVarIndex);
-                        g_ofstream << GetIndentString(nIndentLevel) << strOutLine << GetSource(m_ProcBodies[i][nNodeIndex], false, procDescriptor.m_ulNumArgs) <<  ";" << std::endl;
+                        m_ofstream << GetIndentString(nIndentLevel) << strOutLine << GetSource(m_ProcBodies[i][nNodeIndex], false, procDescriptor.m_ulNumArgs) <<  ";" << std::endl;
                         ulLocalVarIndex++;
                         break;
                     }
                     case COpcode::O_IF:
-                        g_ofstream << GetIndentString(nIndentLevel) << GetSource(m_ProcBodies[i][nNodeIndex], false, procDescriptor.m_ulNumArgs) << " then ";
+                        m_ofstream << GetIndentString(nIndentLevel) << GetSource(m_ProcBodies[i][nNodeIndex], false, procDescriptor.m_ulNumArgs) << " then ";
                         break;
 
                     case COpcode::O_WHILE:
@@ -472,16 +470,16 @@ void CFalloutScript::StoreDeclarations()
                                 str += GetSource(m_ProcBodies[i][nNodeIndex].m_Arguments[j], false, procDescriptor.m_ulNumArgs);
                             }
                             str += ") ";
-                            g_ofstream << str;
+                            m_ofstream << str;
                         }
                         else
                         {
-                            g_ofstream << GetIndentString(nIndentLevel) << GetSource(m_ProcBodies[i][nNodeIndex], false, procDescriptor.m_ulNumArgs) << " do ";
+                            m_ofstream << GetIndentString(nIndentLevel) << GetSource(m_ProcBodies[i][nNodeIndex], false, procDescriptor.m_ulNumArgs) << " do ";
                         }
                         break;
 
                     default:
-                        g_ofstream << GetIndentString(nIndentLevel) << GetSource(m_ProcBodies[i][nNodeIndex], false, procDescriptor.m_ulNumArgs) << ";" << std::endl;
+                        m_ofstream << GetIndentString(nIndentLevel) << GetSource(m_ProcBodies[i][nNodeIndex], false, procDescriptor.m_ulNumArgs) << ";" << std::endl;
 
                         if ((m_ProcBodies[i][nNodeIndex].m_Type != CNode::TYPE_BEGIN_OF_BLOCK) &&
                             (m_ProcBodies[i][nNodeIndex].m_Type != CNode::TYPE_END_OF_BLOCK))
@@ -492,7 +490,7 @@ void CFalloutScript::StoreDeclarations()
             }
         }
 
-        g_ofstream << std::endl;
+        m_ofstream << std::endl;
     }
 }
 

--- a/Namespace.cpp
+++ b/Namespace.cpp
@@ -27,16 +27,16 @@ CNamespace::~CNamespace()
 {
 }
 
-void CNamespace::Serialize(std::ifstream& ifstream)
+void CNamespace::Serialize(CFalloutScriptData& scriptData)
 {
     m_Map.RemoveAll();
     m_Order.clear();
 
     uint32_t ulLength;
-    ifstream.read((char*)&ulLength, sizeof(ulLength));
+    scriptData.inputStream.read((char*)&ulLength, sizeof(ulLength));
     std::reverse((char*)&ulLength, (char*)&ulLength + sizeof(ulLength));
 
-    if (!ifstream)
+    if (!scriptData.inputStream)
     {
         std::cout << "Error: Unable read length of namespace" << std::endl;
         throw std::exception();
@@ -52,10 +52,10 @@ void CNamespace::Serialize(std::ifstream& ifstream)
     {
         std::string strNewString;
 
-        ifstream.read((char*)&wLengthOfString, sizeof(wLengthOfString));
+        scriptData.inputStream.read((char*)&wLengthOfString, sizeof(wLengthOfString));
         std::reverse((char*)&wLengthOfString, (char*)&wLengthOfString + sizeof(wLengthOfString));
 
-        if (!ifstream)
+        if (!scriptData.inputStream)
         {
             std::cout << "Error: Unable read length of string" << std::endl;
             throw std::exception();
@@ -70,8 +70,8 @@ void CNamespace::Serialize(std::ifstream& ifstream)
         strNewString.resize(wLengthOfString);
         lpszNewString = (char*)strNewString.data();
 
-        ifstream.read(lpszNewString, wLengthOfString);
-        if (!ifstream)
+        scriptData.inputStream.read(lpszNewString, wLengthOfString);
+        if (!scriptData.inputStream)
         {
             strNewString.resize(0);
             std::cout << "Error: Unable read string in namespace" << std::endl;
@@ -105,10 +105,10 @@ void CNamespace::Serialize(std::ifstream& ifstream)
 
     uint32_t ulTerminator;
 
-    ifstream.read((char*)&ulTerminator, sizeof(ulTerminator));
+    scriptData.inputStream.read((char*)&ulTerminator, sizeof(ulTerminator));
     std::reverse((char*)&ulTerminator, (char*)&ulTerminator + sizeof(ulTerminator));
 
-    if (!ifstream)
+    if (!scriptData.inputStream)
     {
         std::cout << "Error: Unable read terminator of namespace" << std::endl;
         throw std::exception();
@@ -143,21 +143,21 @@ uint32_t CNamespace::GetOffsetByIndex(int32_t nIndex)
     return m_Order[nIndex];
 }
 
-void CNamespace::Dump(std::ofstream& ofstream)
+void CNamespace::Dump(CFalloutScriptData& scriptData)
 {
     if (m_Order.empty())
     {
-        ofstream << "Empty" << std::endl;
+        scriptData.outputStream << "Empty" << std::endl;
     }
     else
     {
         for(unsigned int i = 0; i < m_Order.size(); i++)
         {
-            ofstream << format("0x%08X: \"%s\"", m_Order[i], GetStringByIndex(i).c_str()) << std::endl;
+            scriptData.outputStream << format("0x%08X: \"%s\"", m_Order[i], GetStringByIndex(i).c_str()) << std::endl;
         }
 
-        ofstream << "==================" << std::endl;
-        ofstream << format("%d item(s)\n", m_Order.size()) << std::endl;
+        scriptData.outputStream << "==================" << std::endl;
+        scriptData.outputStream << format("%d item(s)\n", m_Order.size()) << std::endl;
     }
 }
 

--- a/Namespace.cpp
+++ b/Namespace.cpp
@@ -18,9 +18,6 @@
 
 // Third party includes
 
-extern std::ifstream g_ifstream;
-extern std::ofstream g_ofstream;
-
 CNamespace::CNamespace()
 {
     m_Map.InitHashTable(128);
@@ -30,16 +27,16 @@ CNamespace::~CNamespace()
 {
 }
 
-void CNamespace::Serialize()
+void CNamespace::Serialize(std::ifstream& ifstream)
 {
     m_Map.RemoveAll();
     m_Order.clear();
 
     uint32_t ulLength;
-    g_ifstream.read((char*)&ulLength, sizeof(ulLength));
+    ifstream.read((char*)&ulLength, sizeof(ulLength));
     std::reverse((char*)&ulLength, (char*)&ulLength + sizeof(ulLength));
 
-    if (!g_ifstream)
+    if (!ifstream)
     {
         std::cout << "Error: Unable read length of namespace" << std::endl;
         throw std::exception();
@@ -55,10 +52,10 @@ void CNamespace::Serialize()
     {
         std::string strNewString;
 
-        g_ifstream.read((char*)&wLengthOfString, sizeof(wLengthOfString));
+        ifstream.read((char*)&wLengthOfString, sizeof(wLengthOfString));
         std::reverse((char*)&wLengthOfString, (char*)&wLengthOfString + sizeof(wLengthOfString));
 
-        if (!g_ifstream)
+        if (!ifstream)
         {
             std::cout << "Error: Unable read length of string" << std::endl;
             throw std::exception();
@@ -73,8 +70,8 @@ void CNamespace::Serialize()
         strNewString.resize(wLengthOfString);
         lpszNewString = (char*)strNewString.data();
 
-        g_ifstream.read(lpszNewString, wLengthOfString);
-        if (!g_ifstream)
+        ifstream.read(lpszNewString, wLengthOfString);
+        if (!ifstream)
         {
             strNewString.resize(0);
             std::cout << "Error: Unable read string in namespace" << std::endl;
@@ -108,10 +105,10 @@ void CNamespace::Serialize()
 
     uint32_t ulTerminator;
 
-    g_ifstream.read((char*)&ulTerminator, sizeof(ulTerminator));
+    ifstream.read((char*)&ulTerminator, sizeof(ulTerminator));
     std::reverse((char*)&ulTerminator, (char*)&ulTerminator + sizeof(ulTerminator));
 
-    if (!g_ifstream)
+    if (!ifstream)
     {
         std::cout << "Error: Unable read terminator of namespace" << std::endl;
         throw std::exception();
@@ -146,21 +143,21 @@ uint32_t CNamespace::GetOffsetByIndex(int32_t nIndex)
     return m_Order[nIndex];
 }
 
-void CNamespace::Dump()
+void CNamespace::Dump(std::ofstream& ofstream)
 {
     if (m_Order.empty())
     {
-        g_ofstream << "Empty" << std::endl;
+        ofstream << "Empty" << std::endl;
     }
     else
     {
         for(unsigned int i = 0; i < m_Order.size(); i++)
         {
-            g_ofstream << format("0x%08X: \"%s\"", m_Order[i], GetStringByIndex(i).c_str()) << std::endl;
+            ofstream << format("0x%08X: \"%s\"", m_Order[i], GetStringByIndex(i).c_str()) << std::endl;
         }
 
-        g_ofstream << "==================" << std::endl;
-        g_ofstream << format("%d item(s)\n", m_Order.size()) << std::endl;
+        ofstream << "==================" << std::endl;
+        ofstream << format("%d item(s)\n", m_Order.size()) << std::endl;
     }
 }
 

--- a/Namespace.h
+++ b/Namespace.h
@@ -11,6 +11,7 @@
 #define NAMESPACE_H
 
 // C++ standard includes
+#include <fstream>
 #include <vector>
 
 // int2ssl includes
@@ -25,14 +26,14 @@ public:
     virtual ~CNamespace();
 
 public:
-    virtual void Serialize();
+    virtual void Serialize(std::ifstream& ifstream);
 
 public:
     int32_t GetSize() const;
     std::string GetStringByIndex(int32_t nIndex) ;
     uint32_t GetOffsetByIndex(int32_t nIndex) ;
 
-    void Dump();
+    void Dump(std::ofstream& ofstream);
 
 public:
     std::string operator [] (uint32_t ulOffset) const;

--- a/Namespace.h
+++ b/Namespace.h
@@ -11,10 +11,10 @@
 #define NAMESPACE_H
 
 // C++ standard includes
-#include <fstream>
 #include <vector>
 
 // int2ssl includes
+#include "FalloutScriptData.h"
 #include "Hacks/CMap.h"
 
 // Third party includes
@@ -26,14 +26,14 @@ public:
     virtual ~CNamespace();
 
 public:
-    virtual void Serialize(std::ifstream& ifstream);
+    virtual void Serialize(CFalloutScriptData& scriptData);
 
 public:
     int32_t GetSize() const;
     std::string GetStringByIndex(int32_t nIndex) ;
     uint32_t GetOffsetByIndex(int32_t nIndex) ;
 
-    void Dump(std::ofstream& ofstream);
+    void Dump(CFalloutScriptData& scriptData);
 
 public:
     std::string operator [] (uint32_t ulOffset) const;

--- a/Node.cpp
+++ b/Node.cpp
@@ -17,9 +17,6 @@
 
 // Third party includes
 
-extern std::ifstream g_ifstream;
-extern std::ofstream g_ofstream;
-
 CNode::CNode(Type type) :
     m_ulOffset(0),
     m_Type(type)
@@ -51,27 +48,27 @@ CNode& CNode::operator = (const CNode& node)
     return (*this);
 }
 
-void CNode::StoreTree(int nIndent, int nIndex)
+void CNode::StoreTree(std::ofstream& ofstream, int nIndent, int nIndex)
 {
     // Indent
     if (nIndex != 0)
     {
-        g_ofstream << "            ";
+        ofstream << "            ";
 
         for(int i = 0; i < nIndent; i++)
         {
-            g_ofstream << "                  ";
+            ofstream << "                  ";
         }
     }
 
     switch(m_Type)
     {
         case TYPE_BEGIN_OF_BLOCK:
-            g_ofstream << "========= begin of block =========" << std::endl;
+            ofstream << "========= begin of block =========" << std::endl;
             return;
 
         case TYPE_END_OF_BLOCK:
-            g_ofstream << "========= end of block =========" << std::endl;
+            ofstream << "========= end of block =========" << std::endl;
             return;
 
         default:
@@ -87,31 +84,31 @@ void CNode::StoreTree(int nIndent, int nIndex)
     {
         case COpcode::O_STRINGOP:
         case COpcode::O_INTOP:
-            g_ofstream << format("0x%04X 0x%08x ",
+            ofstream << format("0x%04X 0x%08x ",
                               wOperator,
                               ulArgument) << std::endl;
             break;
 
         case COpcode::O_FLOATOP:
-            g_ofstream << format("0x%04X 0x%08X ",
+            ofstream << format("0x%04X 0x%08X ",
                                 wOperator,
                                 ulArgument) << std::endl;
             break;
 
         default:
-            g_ofstream << format("0x%04X .......... ", wOperator) << std::endl;
+            ofstream << format("0x%04X .......... ", wOperator) << std::endl;
             break;
     }
     if (!m_Arguments.empty())
     {
         for(uint32_t i = 0; i < m_Arguments.size(); i++)
         {
-            m_Arguments[i].StoreTree(nIndent + 1, i);
+            m_Arguments[i].StoreTree(ofstream, nIndent + 1, i);
         }
     }
     else
     {
-        g_ofstream << std::endl;
+        ofstream << std::endl;
     }
 
 }

--- a/Node.cpp
+++ b/Node.cpp
@@ -48,27 +48,27 @@ CNode& CNode::operator = (const CNode& node)
     return (*this);
 }
 
-void CNode::StoreTree(std::ofstream& ofstream, int nIndent, int nIndex)
+void CNode::StoreTree(CFalloutScriptData& scriptData, int nIndent, int nIndex)
 {
     // Indent
     if (nIndex != 0)
     {
-        ofstream << "            ";
+        scriptData.outputStream << "            ";
 
         for(int i = 0; i < nIndent; i++)
         {
-            ofstream << "                  ";
+            scriptData.outputStream << "                  ";
         }
     }
 
     switch(m_Type)
     {
         case TYPE_BEGIN_OF_BLOCK:
-            ofstream << "========= begin of block =========" << std::endl;
+            scriptData.outputStream << "========= begin of block =========" << std::endl;
             return;
 
         case TYPE_END_OF_BLOCK:
-            ofstream << "========= end of block =========" << std::endl;
+            scriptData.outputStream << "========= end of block =========" << std::endl;
             return;
 
         default:
@@ -84,31 +84,31 @@ void CNode::StoreTree(std::ofstream& ofstream, int nIndent, int nIndex)
     {
         case COpcode::O_STRINGOP:
         case COpcode::O_INTOP:
-            ofstream << format("0x%04X 0x%08x ",
+            scriptData.outputStream << format("0x%04X 0x%08x ",
                               wOperator,
                               ulArgument) << std::endl;
             break;
 
         case COpcode::O_FLOATOP:
-            ofstream << format("0x%04X 0x%08X ",
+            scriptData.outputStream << format("0x%04X 0x%08X ",
                                 wOperator,
                                 ulArgument) << std::endl;
             break;
 
         default:
-            ofstream << format("0x%04X .......... ", wOperator) << std::endl;
+            scriptData.outputStream << format("0x%04X .......... ", wOperator) << std::endl;
             break;
     }
     if (!m_Arguments.empty())
     {
         for(uint32_t i = 0; i < m_Arguments.size(); i++)
         {
-            m_Arguments[i].StoreTree(ofstream, nIndent + 1, i);
+            m_Arguments[i].StoreTree(scriptData, nIndent + 1, i);
         }
     }
     else
     {
-        ofstream << std::endl;
+        scriptData.outputStream << std::endl;
     }
 
 }

--- a/Node.h
+++ b/Node.h
@@ -13,11 +13,11 @@
 // C++ standard includes
 
 // int2ssl includes
+#include "FalloutScriptData.h"
 #include "Namespace.h"
 #include "Opcode.h"
 
 // Third party includes
-#include <fstream>
 
 class CNode;
 typedef std::vector<CNode> CNodeArray;
@@ -46,7 +46,7 @@ public:
     CNode& operator = (const CNode& node);
 
 public:
-    void StoreTree(std::ofstream& ofstream, int nIndent, int nIndex);
+    void StoreTree(CFalloutScriptData& scriptData, int nIndent, int nIndex);
     uint32_t  GetTopOffset();
     bool IsExpression() const;
     bool IsInfix() const;

--- a/Node.h
+++ b/Node.h
@@ -17,6 +17,7 @@
 #include "Opcode.h"
 
 // Third party includes
+#include <fstream>
 
 class CNode;
 typedef std::vector<CNode> CNodeArray;
@@ -45,7 +46,7 @@ public:
     CNode& operator = (const CNode& node);
 
 public:
-    void StoreTree(int nIndent, int nIndex);
+    void StoreTree(std::ofstream& ofstream, int nIndent, int nIndex);
     uint32_t  GetTopOffset();
     bool IsExpression() const;
     bool IsInfix() const;

--- a/Opcode.cpp
+++ b/Opcode.cpp
@@ -19,7 +19,6 @@
 // Third party includes
 
 extern int g_nFalloutVersion;
-extern std::ifstream g_ifstream;
 
 COpcode::COpcode() :
     m_wOperator(O_NOOP),
@@ -46,12 +45,12 @@ COpcode& COpcode::operator = (const COpcode& opcode)
     return (*this);
 }
 
-void COpcode::Serialize()
+void COpcode::Serialize(std::ifstream& ifstream)
 {
-    g_ifstream.read((char*)&m_wOperator, sizeof(m_wOperator));
+    ifstream.read((char*)&m_wOperator, sizeof(m_wOperator));
     std::reverse((char*)&m_wOperator, (char*)&m_wOperator + sizeof(m_wOperator));
 
-    if (!g_ifstream)
+    if (!ifstream)
     {
         printf("Error: Unable read opcode\n");
         throw std::exception();
@@ -65,16 +64,16 @@ void COpcode::Serialize()
          (m_wOperator != O_FLOATOP)&&
          (m_wOperator != O_INTOP)))
     {
-        printf("Error: Invalid opcode at 0x%08x\n", (uint32_t)g_ifstream.tellg() - 2);
+        printf("Error: Invalid opcode at 0x%08x\n", (uint32_t)ifstream.tellg() - 2);
         throw std::exception();
     }
 
     if ((m_wOperator == O_STRINGOP) || (m_wOperator == O_FLOATOP) || (m_wOperator == O_INTOP))
     {
-        g_ifstream.read((char*)&m_ulArgument, sizeof(m_ulArgument));
+        ifstream.read((char*)&m_ulArgument, sizeof(m_ulArgument));
         std::reverse((char*)&m_ulArgument, (char*)&m_ulArgument + sizeof(m_ulArgument));
 
-        if (!g_ifstream)
+        if (!ifstream)
         {
             std::cout << "Error: Unable read opcode argument" << std::endl;
             throw std::exception();
@@ -82,9 +81,9 @@ void COpcode::Serialize()
     }
 }
 
-void COpcode::Expect(uint16_t wOperator, bool bArgumentFound, uint32_t ulArgument)
+void COpcode::Expect(std::ifstream& ifstream, uint16_t wOperator, bool bArgumentFound, uint32_t ulArgument)
 {
-    Serialize();
+    Serialize(ifstream);
 
     if (m_wOperator != wOperator)
     {
@@ -102,9 +101,9 @@ void COpcode::Expect(uint16_t wOperator, bool bArgumentFound, uint32_t ulArgumen
     }
 }
 
-void COpcode::Expect(int nCount, uint16_t pwOperators[])
+void COpcode::Expect(std::ifstream& ifstream, int nCount, uint16_t pwOperators[])
 {
-    Serialize();
+    Serialize(ifstream);
     bool bFound = false;
 
     for(int i = 0; i < nCount; i++)

--- a/Opcode.cpp
+++ b/Opcode.cpp
@@ -45,12 +45,12 @@ COpcode& COpcode::operator = (const COpcode& opcode)
     return (*this);
 }
 
-void COpcode::Serialize(std::ifstream& ifstream)
+void COpcode::Serialize(CFalloutScriptData& scriptData)
 {
-    ifstream.read((char*)&m_wOperator, sizeof(m_wOperator));
+    scriptData.inputStream.read((char*)&m_wOperator, sizeof(m_wOperator));
     std::reverse((char*)&m_wOperator, (char*)&m_wOperator + sizeof(m_wOperator));
 
-    if (!ifstream)
+    if (!scriptData.inputStream)
     {
         printf("Error: Unable read opcode\n");
         throw std::exception();
@@ -64,16 +64,16 @@ void COpcode::Serialize(std::ifstream& ifstream)
          (m_wOperator != O_FLOATOP)&&
          (m_wOperator != O_INTOP)))
     {
-        printf("Error: Invalid opcode at 0x%08x\n", (uint32_t)ifstream.tellg() - 2);
+        printf("Error: Invalid opcode at 0x%08x\n", (uint32_t)scriptData.inputStream.tellg() - 2);
         throw std::exception();
     }
 
     if ((m_wOperator == O_STRINGOP) || (m_wOperator == O_FLOATOP) || (m_wOperator == O_INTOP))
     {
-        ifstream.read((char*)&m_ulArgument, sizeof(m_ulArgument));
+        scriptData.inputStream.read((char*)&m_ulArgument, sizeof(m_ulArgument));
         std::reverse((char*)&m_ulArgument, (char*)&m_ulArgument + sizeof(m_ulArgument));
 
-        if (!ifstream)
+        if (!scriptData.inputStream)
         {
             std::cout << "Error: Unable read opcode argument" << std::endl;
             throw std::exception();
@@ -81,9 +81,9 @@ void COpcode::Serialize(std::ifstream& ifstream)
     }
 }
 
-void COpcode::Expect(std::ifstream& ifstream, uint16_t wOperator, bool bArgumentFound, uint32_t ulArgument)
+void COpcode::Expect(CFalloutScriptData& scriptData, uint16_t wOperator, bool bArgumentFound, uint32_t ulArgument)
 {
-    Serialize(ifstream);
+    Serialize(scriptData);
 
     if (m_wOperator != wOperator)
     {
@@ -101,9 +101,9 @@ void COpcode::Expect(std::ifstream& ifstream, uint16_t wOperator, bool bArgument
     }
 }
 
-void COpcode::Expect(std::ifstream& ifstream, int nCount, uint16_t pwOperators[])
+void COpcode::Expect(CFalloutScriptData& scriptData, int nCount, uint16_t pwOperators[])
 {
-    Serialize(ifstream);
+    Serialize(scriptData);
     bool bFound = false;
 
     for(int i = 0; i < nCount; i++)

--- a/Opcode.h
+++ b/Opcode.h
@@ -11,6 +11,7 @@
 #define OPCODE_H
 
 // C++ standard includes
+#include <fstream>
 #include <vector>
 #include <string>
 
@@ -853,9 +854,9 @@ public:
     COpcode& operator = (const COpcode& opcode);
 
 public:
-    virtual void Serialize();
-    void Expect(uint16_t wOperator, bool bArgumentFound = false, uint32_t ulArgument = 0);
-    void Expect(int nCount, uint16_t pwOperators[]);
+    virtual void Serialize(std::ifstream& ifstream);
+    void Expect(std::ifstream& ifstream, uint16_t wOperator, bool bArgumentFound = false, uint32_t ulArgument = 0);
+    void Expect(std::ifstream& ifstream, int nCount, uint16_t pwOperators[]);
 
     bool HasArgument() const;
     int GetSize() const;

--- a/Opcode.h
+++ b/Opcode.h
@@ -11,11 +11,11 @@
 #define OPCODE_H
 
 // C++ standard includes
-#include <fstream>
 #include <vector>
 #include <string>
 
 // int2ssl includes
+#include "FalloutScriptData.h"
 #include "Hacks/CMap.h"
 
 // Third party includes
@@ -854,9 +854,9 @@ public:
     COpcode& operator = (const COpcode& opcode);
 
 public:
-    virtual void Serialize(std::ifstream& ifstream);
-    void Expect(std::ifstream& ifstream, uint16_t wOperator, bool bArgumentFound = false, uint32_t ulArgument = 0);
-    void Expect(std::ifstream& ifstream, int nCount, uint16_t pwOperators[]);
+    virtual void Serialize(CFalloutScriptData& scriptData);
+    void Expect(CFalloutScriptData& scriptData, uint16_t wOperator, bool bArgumentFound = false, uint32_t ulArgument = 0);
+    void Expect(CFalloutScriptData& scriptData, int nCount, uint16_t pwOperators[]);
 
     bool HasArgument() const;
     int GetSize() const;

--- a/ProcTable.cpp
+++ b/ProcTable.cpp
@@ -21,9 +21,6 @@
 
 // Third party includes
 
-extern std::ifstream g_ifstream;
-extern std::ofstream g_ofstream;
-
 CProcDescriptor::CProcDescriptor() :
     m_ulNameOffset(0),
     m_ulType(0),
@@ -64,30 +61,30 @@ CProcDescriptor& CProcDescriptor::operator = (const CProcDescriptor& Item)
     return (*this);
 }
 
-void CProcDescriptor::Serialize()
+void CProcDescriptor::Serialize(std::ifstream& ifstream)
 {
 
-    g_ifstream.read((char*)&m_ulNameOffset, sizeof(m_ulNameOffset));
+    ifstream.read((char*)&m_ulNameOffset, sizeof(m_ulNameOffset));
     std::reverse((char*)&m_ulNameOffset, (char*)&m_ulNameOffset + sizeof(m_ulNameOffset));
-    g_ifstream.read((char*)&m_ulType, sizeof(m_ulType));
+    ifstream.read((char*)&m_ulType, sizeof(m_ulType));
     std::reverse((char*)&m_ulType, (char*)&m_ulType + sizeof(m_ulType));
-    g_ifstream.read((char*)&m_ulTime, sizeof(m_ulTime));
+    ifstream.read((char*)&m_ulTime, sizeof(m_ulTime));
     std::reverse((char*)&m_ulTime, (char*)&m_ulTime + sizeof(m_ulTime));
-    g_ifstream.read((char*)&m_ulExpressionOffset, sizeof(m_ulExpressionOffset));
+    ifstream.read((char*)&m_ulExpressionOffset, sizeof(m_ulExpressionOffset));
     std::reverse((char*)&m_ulExpressionOffset, (char*)&m_ulExpressionOffset + sizeof(m_ulExpressionOffset));
-    g_ifstream.read((char*)&m_ulBodyOffset, sizeof(m_ulBodyOffset));
+    ifstream.read((char*)&m_ulBodyOffset, sizeof(m_ulBodyOffset));
     std::reverse((char*)&m_ulBodyOffset, (char*)&m_ulBodyOffset + sizeof(m_ulBodyOffset));
-    g_ifstream.read((char*)&m_ulNumArgs, sizeof(m_ulNumArgs));
+    ifstream.read((char*)&m_ulNumArgs, sizeof(m_ulNumArgs));
     std::reverse((char*)&m_ulNumArgs, (char*)&m_ulNumArgs + sizeof(m_ulNumArgs));
 
-    if (!g_ifstream)
+    if (!ifstream)
     {
         std::cout << "Error: Unable read procedure descriptor" << std::endl;
         throw std::exception();
     }
 }
 
-void CProcDescriptor::Dump()
+void CProcDescriptor::Dump(std::ofstream& ofstream)
 {
     std::string strType;
 
@@ -125,12 +122,12 @@ void CProcDescriptor::Dump()
         strType = "No special types";
     }
 
-    g_ofstream << format("Name offset:       0x%08X", m_ulNameOffset) << std::endl;
-    g_ofstream << format("Type:              0x%08X  // %s", m_ulType, strType.c_str()) << std::endl;
-    g_ofstream << format("Time:              0x%08X  // %d", m_ulTime, m_ulTime) << std::endl;
-    g_ofstream << format("Expression offset: 0x%08X", m_ulExpressionOffset) << std::endl;
-    g_ofstream << format("Body offset:       0x%08X", m_ulBodyOffset) << std::endl;
-    g_ofstream << format("Number of args:    0x%08X  // %d", m_ulNumArgs, m_ulNumArgs) << std::endl;
+    ofstream << format("Name offset:       0x%08X", m_ulNameOffset) << std::endl;
+    ofstream << format("Type:              0x%08X  // %s", m_ulType, strType.c_str()) << std::endl;
+    ofstream << format("Time:              0x%08X  // %d", m_ulTime, m_ulTime) << std::endl;
+    ofstream << format("Expression offset: 0x%08X", m_ulExpressionOffset) << std::endl;
+    ofstream << format("Body offset:       0x%08X", m_ulBodyOffset) << std::endl;
+    ofstream << format("Number of args:    0x%08X  // %d", m_ulNumArgs, m_ulNumArgs) << std::endl;
 }
 
 
@@ -177,22 +174,22 @@ int compareProcBodyOffsets(const void* elem0, const void* elem1)
     }
 }
 
-void CProcTable::Serialize()
+void CProcTable::Serialize(std::ifstream& ifstream)
 {
     m_Table.clear();
     m_ProcSize.clear();
 
-    uint32_t oldPosition = g_ifstream.tellg();
-    g_ifstream.seekg(0, std::ios_base::end);
+    uint32_t oldPosition = ifstream.tellg();
+    ifstream.seekg(0, std::ios_base::end);
 
-    uint32_t ulSizeOfFile = g_ifstream.tellg();
-    g_ifstream.seekg(oldPosition, std::ios_base::beg);
+    uint32_t ulSizeOfFile = ifstream.tellg();
+    ifstream.seekg(oldPosition, std::ios_base::beg);
 
     uint32_t ulSizeOfTable;
-    g_ifstream.read((char*)&ulSizeOfTable, sizeof(ulSizeOfTable));
+    ifstream.read((char*)&ulSizeOfTable, sizeof(ulSizeOfTable));
     std::reverse((char*)&ulSizeOfTable, (char*)&ulSizeOfTable + sizeof(ulSizeOfTable));
 
-    if (!g_ifstream)
+    if (!ifstream)
     {
         printf("Error: Unable read size of procedures table\n");
         throw std::exception();
@@ -212,7 +209,7 @@ void CProcTable::Serialize()
     for(uint32_t i = 0; i < ulSizeOfTable; i++)
     {
 //      printf("======== %u =========\n", i);
-        m_Table[i].Serialize();
+        m_Table[i].Serialize(ifstream);
         m_ProcSize[i] = 0;       // Initialize size of procedure
 
         if (!(m_Table[i].m_ulType & P_IMPORT))
@@ -293,13 +290,13 @@ uint32_t CProcTable::GetOffsetOfProcSection()
 }
 
 
-void CProcTable::Dump()
+void CProcTable::Dump(std::ofstream& ofstream)
 {
     for(unsigned int i = 0; i < m_Table.size(); i++)
     {
-        g_ofstream << format("======== Procedure %d ========", i) << std::endl;
-        m_Table[i].Dump();
-        g_ofstream << std::endl;
+        ofstream << format("======== Procedure %d ========", i) << std::endl;
+        m_Table[i].Dump(ofstream);
+        ofstream << std::endl;
     }
 }
 

--- a/ProcTable.cpp
+++ b/ProcTable.cpp
@@ -61,30 +61,30 @@ CProcDescriptor& CProcDescriptor::operator = (const CProcDescriptor& Item)
     return (*this);
 }
 
-void CProcDescriptor::Serialize(std::ifstream& ifstream)
+void CProcDescriptor::Serialize(CFalloutScriptData& scriptData)
 {
 
-    ifstream.read((char*)&m_ulNameOffset, sizeof(m_ulNameOffset));
+    scriptData.inputStream.read((char*)&m_ulNameOffset, sizeof(m_ulNameOffset));
     std::reverse((char*)&m_ulNameOffset, (char*)&m_ulNameOffset + sizeof(m_ulNameOffset));
-    ifstream.read((char*)&m_ulType, sizeof(m_ulType));
+    scriptData.inputStream.read((char*)&m_ulType, sizeof(m_ulType));
     std::reverse((char*)&m_ulType, (char*)&m_ulType + sizeof(m_ulType));
-    ifstream.read((char*)&m_ulTime, sizeof(m_ulTime));
+    scriptData.inputStream.read((char*)&m_ulTime, sizeof(m_ulTime));
     std::reverse((char*)&m_ulTime, (char*)&m_ulTime + sizeof(m_ulTime));
-    ifstream.read((char*)&m_ulExpressionOffset, sizeof(m_ulExpressionOffset));
+    scriptData.inputStream.read((char*)&m_ulExpressionOffset, sizeof(m_ulExpressionOffset));
     std::reverse((char*)&m_ulExpressionOffset, (char*)&m_ulExpressionOffset + sizeof(m_ulExpressionOffset));
-    ifstream.read((char*)&m_ulBodyOffset, sizeof(m_ulBodyOffset));
+    scriptData.inputStream.read((char*)&m_ulBodyOffset, sizeof(m_ulBodyOffset));
     std::reverse((char*)&m_ulBodyOffset, (char*)&m_ulBodyOffset + sizeof(m_ulBodyOffset));
-    ifstream.read((char*)&m_ulNumArgs, sizeof(m_ulNumArgs));
+    scriptData.inputStream.read((char*)&m_ulNumArgs, sizeof(m_ulNumArgs));
     std::reverse((char*)&m_ulNumArgs, (char*)&m_ulNumArgs + sizeof(m_ulNumArgs));
 
-    if (!ifstream)
+    if (!scriptData.inputStream)
     {
         std::cout << "Error: Unable read procedure descriptor" << std::endl;
         throw std::exception();
     }
 }
 
-void CProcDescriptor::Dump(std::ofstream& ofstream)
+void CProcDescriptor::Dump(CFalloutScriptData& scriptData)
 {
     std::string strType;
 
@@ -122,12 +122,12 @@ void CProcDescriptor::Dump(std::ofstream& ofstream)
         strType = "No special types";
     }
 
-    ofstream << format("Name offset:       0x%08X", m_ulNameOffset) << std::endl;
-    ofstream << format("Type:              0x%08X  // %s", m_ulType, strType.c_str()) << std::endl;
-    ofstream << format("Time:              0x%08X  // %d", m_ulTime, m_ulTime) << std::endl;
-    ofstream << format("Expression offset: 0x%08X", m_ulExpressionOffset) << std::endl;
-    ofstream << format("Body offset:       0x%08X", m_ulBodyOffset) << std::endl;
-    ofstream << format("Number of args:    0x%08X  // %d", m_ulNumArgs, m_ulNumArgs) << std::endl;
+    scriptData.outputStream << format("Name offset:       0x%08X", m_ulNameOffset) << std::endl;
+    scriptData.outputStream << format("Type:              0x%08X  // %s", m_ulType, strType.c_str()) << std::endl;
+    scriptData.outputStream << format("Time:              0x%08X  // %d", m_ulTime, m_ulTime) << std::endl;
+    scriptData.outputStream << format("Expression offset: 0x%08X", m_ulExpressionOffset) << std::endl;
+    scriptData.outputStream << format("Body offset:       0x%08X", m_ulBodyOffset) << std::endl;
+    scriptData.outputStream << format("Number of args:    0x%08X  // %d", m_ulNumArgs, m_ulNumArgs) << std::endl;
 }
 
 
@@ -174,22 +174,22 @@ int compareProcBodyOffsets(const void* elem0, const void* elem1)
     }
 }
 
-void CProcTable::Serialize(std::ifstream& ifstream)
+void CProcTable::Serialize(CFalloutScriptData& scriptData)
 {
     m_Table.clear();
     m_ProcSize.clear();
 
-    uint32_t oldPosition = ifstream.tellg();
-    ifstream.seekg(0, std::ios_base::end);
+    uint32_t oldPosition = scriptData.inputStream.tellg();
+    scriptData.inputStream.seekg(0, std::ios_base::end);
 
-    uint32_t ulSizeOfFile = ifstream.tellg();
-    ifstream.seekg(oldPosition, std::ios_base::beg);
+    uint32_t ulSizeOfFile = scriptData.inputStream.tellg();
+    scriptData.inputStream.seekg(oldPosition, std::ios_base::beg);
 
     uint32_t ulSizeOfTable;
-    ifstream.read((char*)&ulSizeOfTable, sizeof(ulSizeOfTable));
+    scriptData.inputStream.read((char*)&ulSizeOfTable, sizeof(ulSizeOfTable));
     std::reverse((char*)&ulSizeOfTable, (char*)&ulSizeOfTable + sizeof(ulSizeOfTable));
 
-    if (!ifstream)
+    if (!scriptData.inputStream)
     {
         printf("Error: Unable read size of procedures table\n");
         throw std::exception();
@@ -209,7 +209,7 @@ void CProcTable::Serialize(std::ifstream& ifstream)
     for(uint32_t i = 0; i < ulSizeOfTable; i++)
     {
 //      printf("======== %u =========\n", i);
-        m_Table[i].Serialize(ifstream);
+        m_Table[i].Serialize(scriptData);
         m_ProcSize[i] = 0;       // Initialize size of procedure
 
         if (!(m_Table[i].m_ulType & P_IMPORT))
@@ -290,13 +290,13 @@ uint32_t CProcTable::GetOffsetOfProcSection()
 }
 
 
-void CProcTable::Dump(std::ofstream& ofstream)
+void CProcTable::Dump(CFalloutScriptData& scriptData)
 {
     for(unsigned int i = 0; i < m_Table.size(); i++)
     {
-        ofstream << format("======== Procedure %d ========", i) << std::endl;
-        m_Table[i].Dump(ofstream);
-        ofstream << std::endl;
+        scriptData.outputStream << format("======== Procedure %d ========", i) << std::endl;
+        m_Table[i].Dump(scriptData);
+        scriptData.outputStream << std::endl;
     }
 }
 

--- a/ProcTable.h
+++ b/ProcTable.h
@@ -11,6 +11,7 @@
 #define PROC_TABLE_H
 
 // C++ standard includes
+#include <fstream>
 #include <stdint.h>
 
 // int2ssl includes
@@ -25,9 +26,9 @@ public:
     virtual ~CProcDescriptor();
 
 public:
-    virtual void Serialize();
+    virtual void Serialize(std::ifstream& ifstream);
 
-    void Dump();
+    void Dump(std::ofstream& ofstream);
 
 public:
     CProcDescriptor& operator = (const CProcDescriptor& Item);
@@ -48,13 +49,13 @@ public:
     virtual ~CProcTable();
 
 public:
-    virtual void Serialize();
+    virtual void Serialize(std::ifstream& ifstream);
 
     uint32_t GetSize();
     uint32_t GetSizeOfProc(uint32_t nIndex);
     uint32_t GetOffsetOfProcSection();
 
-    void Dump();
+    void Dump(std::ofstream& ofstream);
 
 public:
     CProcDescriptor& operator [] (uint32_t nIndex);

--- a/ProcTable.h
+++ b/ProcTable.h
@@ -11,10 +11,10 @@
 #define PROC_TABLE_H
 
 // C++ standard includes
-#include <fstream>
 #include <stdint.h>
 
 // int2ssl includes
+#include "FalloutScriptData.h"
 
 // Third party includes
 
@@ -26,9 +26,9 @@ public:
     virtual ~CProcDescriptor();
 
 public:
-    virtual void Serialize(std::ifstream& ifstream);
+    virtual void Serialize(CFalloutScriptData& scriptData);
 
-    void Dump(std::ofstream& ofstream);
+    void Dump(CFalloutScriptData& scriptData);
 
 public:
     CProcDescriptor& operator = (const CProcDescriptor& Item);
@@ -49,13 +49,13 @@ public:
     virtual ~CProcTable();
 
 public:
-    virtual void Serialize(std::ifstream& ifstream);
+    virtual void Serialize(CFalloutScriptData& scriptData);
 
     uint32_t GetSize();
     uint32_t GetSizeOfProc(uint32_t nIndex);
     uint32_t GetOffsetOfProcSection();
 
-    void Dump(std::ofstream& ofstream);
+    void Dump(CFalloutScriptData& scriptData);
 
 public:
     CProcDescriptor& operator [] (uint32_t nIndex);

--- a/StartupCode.cpp
+++ b/StartupCode.cpp
@@ -22,7 +22,7 @@ CStartupCode::~CStartupCode()
 {
 }
 
-void CStartupCode::Serialize()
+void CStartupCode::Serialize(std::ifstream& ifstream)
 {
     uint16_t wExpectOpcodes[17] = {
         COpcode::O_CRITICAL_START,
@@ -48,11 +48,11 @@ void CStartupCode::Serialize()
     {
         if (i == 1)
         {
-            m_Code[i].Expect(wExpectOpcodes[i], true, 18);
+            m_Code[i].Expect(ifstream, wExpectOpcodes[i], true, 18);
         }
         else
         {
-            m_Code[i].Expect(wExpectOpcodes[i]);
+            m_Code[i].Expect(ifstream, wExpectOpcodes[i]);
         }
     }
 }

--- a/StartupCode.cpp
+++ b/StartupCode.cpp
@@ -22,7 +22,7 @@ CStartupCode::~CStartupCode()
 {
 }
 
-void CStartupCode::Serialize(std::ifstream& ifstream)
+void CStartupCode::Serialize(CFalloutScriptData& scriptData)
 {
     uint16_t wExpectOpcodes[17] = {
         COpcode::O_CRITICAL_START,
@@ -48,11 +48,11 @@ void CStartupCode::Serialize(std::ifstream& ifstream)
     {
         if (i == 1)
         {
-            m_Code[i].Expect(ifstream, wExpectOpcodes[i], true, 18);
+            m_Code[i].Expect(scriptData, wExpectOpcodes[i], true, 18);
         }
         else
         {
-            m_Code[i].Expect(ifstream, wExpectOpcodes[i]);
+            m_Code[i].Expect(scriptData, wExpectOpcodes[i]);
         }
     }
 }

--- a/StartupCode.h
+++ b/StartupCode.h
@@ -11,6 +11,7 @@
 #define STARTUP_CODE_H
 
 // C++ standard includes
+#include <fstream>
 
 // int2ssl includes
 #include "Opcode.h"
@@ -27,7 +28,7 @@ public:
 
     CStartupCode();
     virtual ~CStartupCode();
-    virtual void Serialize();
+    virtual void Serialize(std::ifstream& ifstream);
 
 private:
     COpcode m_Code[17];

--- a/StartupCode.h
+++ b/StartupCode.h
@@ -11,9 +11,9 @@
 #define STARTUP_CODE_H
 
 // C++ standard includes
-#include <fstream>
 
 // int2ssl includes
+#include "FalloutScriptData.h"
 #include "Opcode.h"
 
 // Third party includes
@@ -28,7 +28,7 @@ public:
 
     CStartupCode();
     virtual ~CStartupCode();
-    virtual void Serialize(std::ifstream& ifstream);
+    virtual void Serialize(CFalloutScriptData& scriptData);
 
 private:
     COpcode m_Code[17];

--- a/main.cpp
+++ b/main.cpp
@@ -26,8 +26,8 @@ std::string  g_strIndentFill("\t");
 bool g_bIgnoreWrongNumOfArgs = false;
 bool g_bInsOmittedArgsBackward = false;
 bool g_bStopOnError = false;
-std::ifstream g_ifstream;
-std::ofstream g_ofstream;
+std::ifstream l_ifstream;
+std::ofstream l_ofstream;
 
 
 std::string g_inputFileName;
@@ -54,8 +54,8 @@ int main(int argc, char* argv[])
         return 1;
     }
 
-    g_ifstream.open(g_inputFileName.c_str(), std::fstream::in | std::fstream::binary);
-    if (!g_ifstream.is_open())
+    l_ifstream.open(g_inputFileName.c_str(), std::fstream::in | std::fstream::binary);
+    if (!l_ifstream.is_open())
     {
         std::cout << "Error: Unable open input file: " << g_inputFileName << std::endl;
         if (g_bStopOnError == true)
@@ -66,8 +66,8 @@ int main(int argc, char* argv[])
         return 1;
     }
 
-    g_ofstream.open(g_outputFileName.c_str(), std::fstream::out | std::fstream::trunc);
-    if (!g_ofstream.is_open())
+    l_ofstream.open(g_outputFileName.c_str(), std::fstream::out | std::fstream::trunc);
+    if (!l_ofstream.is_open())
     {
         std::cout << "Error: Unable open output file: " << g_outputFileName << std::endl;
         if (g_bStopOnError == true)
@@ -80,7 +80,7 @@ int main(int argc, char* argv[])
 
     try
     {
-        CFalloutScript Script;
+        CFalloutScript Script(l_ifstream, l_ofstream);
 
         std::cout << format("Loading file %s...", g_inputFileName) << std::endl;
         Script.Serialize();

--- a/main.cpp
+++ b/main.cpp
@@ -26,9 +26,6 @@ std::string  g_strIndentFill("\t");
 bool g_bIgnoreWrongNumOfArgs = false;
 bool g_bInsOmittedArgsBackward = false;
 bool g_bStopOnError = false;
-std::ifstream l_ifstream;
-std::ofstream l_ofstream;
-
 
 std::string g_inputFileName;
 std::string g_outputFileName;
@@ -54,8 +51,10 @@ int main(int argc, char* argv[])
         return 1;
     }
 
-    l_ifstream.open(g_inputFileName.c_str(), std::fstream::in | std::fstream::binary);
-    if (!l_ifstream.is_open())
+    CFalloutScriptData data;
+
+    data.inputStream.open(g_inputFileName.c_str(), std::fstream::in | std::fstream::binary);
+    if (!data.inputStream.is_open())
     {
         std::cout << "Error: Unable open input file: " << g_inputFileName << std::endl;
         if (g_bStopOnError == true)
@@ -66,8 +65,8 @@ int main(int argc, char* argv[])
         return 1;
     }
 
-    l_ofstream.open(g_outputFileName.c_str(), std::fstream::out | std::fstream::trunc);
-    if (!l_ofstream.is_open())
+    data.outputStream.open(g_outputFileName.c_str(), std::fstream::out | std::fstream::trunc);
+    if (!data.outputStream.is_open())
     {
         std::cout << "Error: Unable open output file: " << g_outputFileName << std::endl;
         if (g_bStopOnError == true)
@@ -80,7 +79,7 @@ int main(int argc, char* argv[])
 
     try
     {
-        CFalloutScript Script(l_ifstream, l_ofstream);
+        CFalloutScript Script(data);
 
         std::cout << format("Loading file %s...", g_inputFileName) << std::endl;
         Script.Serialize();


### PR DESCRIPTION
### What?

Replaced `g_[io]fstream` with `CFalloutScript::m_[io]fstream&` and tweaked related code.

### Why?

While pointless looking on its own, end goal is to make source ready to be built as static library at some point in future.

### Wow!

"Detach" here means replacing hardcore dependency with dependency injection; while int2ssl keeps preparing streams inside `main.cpp`, other application will have it easier to implement different configuration source without it (own command line handling / config file / GUI / smoke signals / etc).
