### PR TITLE
Fixed compiler warnings, removed CMap::InitHashTable() (empty function)

### DIFF
--- a/FalloutScript.h
+++ b/FalloutScript.h
@@ -68,14 +68,13 @@ private:
     void ExtractAndReduceCondition(CNodeArray& Source, CNodeArray& Destination, int32_t nStartIndex);
     void SetBordersOfBlocks(CNodeArray& NodeArray);
     uint32_t BuildTreeBranch(CNodeArray& NodeArray, uint32_t nStartIndex, uint32_t ulEndOffset);
-    void ReduceConditionalExpressions(CNodeArray& NodeArray);
     bool IsOmittetArgsAllowed(uint16_t wOpcode);
 
     void StoreDefinitions();
     void StoreDeclarations();
 
     std::string GetSource( CNode& node, bool bLabel, uint32_t ulNumArgs);
-    std::string GetSource( CNode& node, bool bLabel, uint32_t ulNumArgs, uint32_t aulProcArg[], uint32_t ulProcArgCount);
+    std::string GetSource( CNode& node, uint32_t ulNumArgs, uint32_t aulProcArg[], uint32_t ulProcArgCount);
     bool ArgNeedParens(const CNode& node, const CNode& argument, CFalloutScript::Assoc assoc = CFalloutScript::NON_ASSOC);
     std::string GetIndentString(int32_t nLevel);
 

--- a/FalloutScriptDecompile.cpp
+++ b/FalloutScriptDecompile.cpp
@@ -855,28 +855,6 @@ void CFalloutScript::SetBordersOfBlocks(CNodeArray& NodeArray)
     }
 }
 
-void CFalloutScript::ReduceConditionalExpressions(CNodeArray& /*NodeArray*/)
-{
-    /*
-    if (NodeArray.IsEmpty())
-    {
-        return;
-    }
-    CNode node;
-
-    for (int32_t i = 0; i < NodeArray.GetSize(); i++)
-    {
-        if (NodeArray[i].m_Opcode.GetOperator() == COpcode::O_IF)
-        {
-            if (ReduceExpressionBlock(NodeArray, i+1))
-            {
-
-            }
-        }
-    }
-    */
-}
-
 bool CFalloutScript::IsOmittetArgsAllowed(uint16_t wOpcode)
 {
     if (((wOpcode >= COpcode::O_END_CORE) && (wOpcode < COpcode::O_END_OP)) ||

--- a/FalloutScriptDecompile.cpp
+++ b/FalloutScriptDecompile.cpp
@@ -855,7 +855,7 @@ void CFalloutScript::SetBordersOfBlocks(CNodeArray& NodeArray)
     }
 }
 
-void CFalloutScript::ReduceConditionalExpressions(CNodeArray& NodeArray)
+void CFalloutScript::ReduceConditionalExpressions(CNodeArray& /*NodeArray*/)
 {
     /*
     if (NodeArray.IsEmpty())

--- a/FalloutScriptStore.cpp
+++ b/FalloutScriptStore.cpp
@@ -782,7 +782,7 @@ std::string CFalloutScript::GetSource(CNode& node, bool bLabel, uint32_t ulNumAr
         case COpcode::O_REFRESHMOUSE:
             {
                 uint32_t aulProcArg[1] = { 1 };
-                strResult = GetSource(node, bLabel, ulNumArgs, aulProcArg, 1);
+                strResult = GetSource(node, ulNumArgs, aulProcArg, 1);
             }
 
             break;
@@ -790,7 +790,7 @@ std::string CFalloutScript::GetSource(CNode& node, bool bLabel, uint32_t ulNumAr
         case COpcode::O_ADDBUTTONPROC:
             {
                 uint32_t aulProcArg[4] = { 2, 3, 4, 5 };
-                strResult = GetSource(node, bLabel, ulNumArgs, aulProcArg, 4);
+                strResult = GetSource(node, ulNumArgs, aulProcArg, 4);
             }
 
             break;
@@ -798,7 +798,7 @@ std::string CFalloutScript::GetSource(CNode& node, bool bLabel, uint32_t ulNumAr
         case COpcode::O_ADDBUTTONRIGHTPROC:
             {
                 uint32_t aulProcArg[2] = { 2, 3 };
-                strResult = GetSource(node, bLabel, ulNumArgs, aulProcArg, 2);
+                strResult = GetSource(node, ulNumArgs, aulProcArg, 2);
             }
 
             break;
@@ -808,7 +808,7 @@ std::string CFalloutScript::GetSource(CNode& node, bool bLabel, uint32_t ulNumAr
                 if (node.m_Arguments[1].m_Opcode.GetOperator() == COpcode::O_INTOP)
                 {
                     uint32_t aulProcArg[2] = { 2 };
-                    strResult = GetSource(node, bLabel, ulNumArgs, aulProcArg, 1);
+                    strResult = GetSource(node, ulNumArgs, aulProcArg, 1);
                 }
                 else
                 {
@@ -822,7 +822,7 @@ std::string CFalloutScript::GetSource(CNode& node, bool bLabel, uint32_t ulNumAr
         case COpcode::O_ADDREGIONPROC:
             {
                 uint32_t aulProcArg[4] = { 2, 3, 4, 5 };
-                strResult = GetSource(node, bLabel, ulNumArgs, aulProcArg, 4);
+                strResult = GetSource(node, ulNumArgs, aulProcArg, 4);
             }
 
             break;
@@ -830,7 +830,7 @@ std::string CFalloutScript::GetSource(CNode& node, bool bLabel, uint32_t ulNumAr
         case COpcode::O_ADDREGIONRIGHTPROC:
             {
                 uint32_t aulProcArg[2] = { 2, 3 };
-                strResult = GetSource(node, bLabel, ulNumArgs, aulProcArg, 2);
+                strResult = GetSource(node, ulNumArgs, aulProcArg, 2);
             }
 
             break;
@@ -838,7 +838,7 @@ std::string CFalloutScript::GetSource(CNode& node, bool bLabel, uint32_t ulNumAr
         case COpcode::O_ADDNAMEDEVENT:
             {
                 uint32_t aulProcArg[1] = { 2 };
-                strResult = GetSource(node, bLabel, ulNumArgs, aulProcArg, 1);
+                strResult = GetSource(node, ulNumArgs, aulProcArg, 1);
             }
 
             break;
@@ -846,7 +846,7 @@ std::string CFalloutScript::GetSource(CNode& node, bool bLabel, uint32_t ulNumAr
         case COpcode::O_ADDNAMEDHANDLER:
             {
                 uint32_t aulProcArg[1] = { 2 };
-                strResult = GetSource(node, bLabel, ulNumArgs, aulProcArg, 1);
+                strResult = GetSource(node, ulNumArgs, aulProcArg, 1);
             }
 
             break;
@@ -854,7 +854,7 @@ std::string CFalloutScript::GetSource(CNode& node, bool bLabel, uint32_t ulNumAr
         case COpcode::O_ADDKEY:
             {
                 uint32_t aulProcArg[1] = { 2 };
-                strResult = GetSource(node, bLabel, ulNumArgs, aulProcArg, 1);
+                strResult = GetSource(node, ulNumArgs, aulProcArg, 1);
             }
 
             break;
@@ -862,7 +862,7 @@ std::string CFalloutScript::GetSource(CNode& node, bool bLabel, uint32_t ulNumAr
         case COpcode::O_GSAY_OPTION:
             {
                 uint32_t aulProcArg[1] = { 3 };
-                strResult = GetSource(node, bLabel, ulNumArgs, aulProcArg, 1);
+                strResult = GetSource(node, ulNumArgs, aulProcArg, 1);
             }
 
             break;
@@ -870,7 +870,7 @@ std::string CFalloutScript::GetSource(CNode& node, bool bLabel, uint32_t ulNumAr
         case COpcode::O_GIQ_OPTION:
             {
                 uint32_t aulProcArg[1] = { 4 };
-                strResult = GetSource(node, bLabel, ulNumArgs, aulProcArg, 1);
+                strResult = GetSource(node, ulNumArgs, aulProcArg, 1);
             }
 
             break;
@@ -899,14 +899,14 @@ std::string CFalloutScript::GetSource(CNode& node, bool bLabel, uint32_t ulNumAr
             }
 
             break;
-            
+
         default:
             COpcode::COpcodeAttributes attributes = node.m_Opcode.GetAttributes();
             uint32_t *procArgs = attributes.m_procArgs;
             uint32_t numProcArgs = attributes.m_numProcArgs;
             if (numProcArgs > 0)
             {
-                strResult = GetSource(node, bLabel, ulNumArgs, procArgs, numProcArgs);
+                strResult = GetSource(node, ulNumArgs, procArgs, numProcArgs);
                 break;
             }
             if (node.m_Type == CNode::TYPE_CONDITIONAL_EXPRESSION)
@@ -941,7 +941,7 @@ std::string CFalloutScript::GetSource(CNode& node, bool bLabel, uint32_t ulNumAr
                     strResult += " ";
                     strResult += attributes.m_strName + " ";
 
-                    
+
                     if (ArgNeedParens(node, node.m_Arguments[1], CFalloutScript::RIGHT_ASSOC))
                     {
                         strResult += "(";
@@ -989,7 +989,7 @@ std::string CFalloutScript::GetSource(CNode& node, bool bLabel, uint32_t ulNumAr
     return strResult;
 }
 
-std::string CFalloutScript::GetSource( CNode& node, bool /*bLabel*/, uint32_t ulNumArgs, uint32_t aulProcArg[], uint32_t ulProcArgCount)
+std::string CFalloutScript::GetSource( CNode& node, uint32_t ulNumArgs, uint32_t aulProcArg[], uint32_t ulProcArgCount)
 {
     COpcode::COpcodeAttributes attributes = node.m_Opcode.GetAttributes();
     std::string strResult = attributes.m_strName + "(";

--- a/FalloutScriptStore.cpp
+++ b/FalloutScriptStore.cpp
@@ -989,7 +989,7 @@ std::string CFalloutScript::GetSource(CNode& node, bool bLabel, uint32_t ulNumAr
     return strResult;
 }
 
-std::string CFalloutScript::GetSource( CNode& node, bool bLabel, uint32_t ulNumArgs, uint32_t aulProcArg[], uint32_t ulProcArgCount)
+std::string CFalloutScript::GetSource( CNode& node, bool /*bLabel*/, uint32_t ulNumArgs, uint32_t aulProcArg[], uint32_t ulProcArgCount)
 {
     COpcode::COpcodeAttributes attributes = node.m_Opcode.GetAttributes();
     std::string strResult = attributes.m_strName + "(";

--- a/Hacks/CMap.h
+++ b/Hacks/CMap.h
@@ -57,11 +57,6 @@ class CMap
             }
             return false;
         }
-
-        void InitHashTable(uint32_t n)
-        {
-
-        }
 };
 
 #endif // CMAP_H

--- a/Namespace.cpp
+++ b/Namespace.cpp
@@ -23,7 +23,6 @@ extern std::ofstream g_ofstream;
 
 CNamespace::CNamespace()
 {
-    m_Map.InitHashTable(128);
 }
 
 CNamespace::~CNamespace()

--- a/OpcodeAttributes.cpp
+++ b/OpcodeAttributes.cpp
@@ -64,8 +64,6 @@ COpcode::CF1OpcodeAttributesMap::CF1OpcodeAttributesMap()
     COpcode::COpcodeAttributes::Type expression = COpcode::COpcodeAttributes::TYPE_EXPRESSION;
     //COpcode::COpcodeAttributes::Category infix = COpcode::COpcodeAttributes::CATEGORY_INFIX;
 
-    InitHashTable(32);
-
     SetAt(O_REACTION, COpcodeAttributes("O_REACTION", "reaction", 3, expression));
     SetAt(O_ANIMATE_JUMP, COpcodeAttributes("O_ANIMATE_JUMP", "animate_jump", 0));
     SetAt(O_TURN_OFF_OBJS_IN_AREA, COpcodeAttributes("O_TURN_OFF_OBJS_IN_AREA", "turn_off_objs_in_area", 4));
@@ -82,8 +80,6 @@ COpcode::CF2OpcodeAttributesMap::CF2OpcodeAttributesMap()
 {
     COpcode::COpcodeAttributes::Type expression = COpcode::COpcodeAttributes::TYPE_EXPRESSION;
     COpcode::COpcodeAttributes::Category infix = COpcode::COpcodeAttributes::CATEGORY_INFIX;
-
-    InitHashTable(512);
 
     SetAt(O_NOOP, COpcodeAttributes("O_NOOP", "/* O_NOOP */", 0));
     SetAt(O_CONST, COpcodeAttributes("O_CONST", "/* O_CONST */", 0));

--- a/XGetopt.cpp
+++ b/XGetopt.cpp
@@ -198,7 +198,8 @@ int getopt(int argc, char *argv[], const char *optstring)
     if (cp == NULL || c == ':')
         return '?';
 
-	cp++;
+    cp++;
+
     if (*cp == ':')
 	{
         if (*next != '\0')


### PR DESCRIPTION
Fixed warnings generated by `gcc -Wall -Wextra -Wpedantic`
- Mostly about unused function arguments, except XGetopt.cpp with misleading indentation

Removed CMap::InitHashTable() as it does nothing anyway
