### PR TITLE
Fixed compiler warning

### DIFF
--- a/FalloutScript.h
+++ b/FalloutScript.h
@@ -11,6 +11,8 @@
 #define FALLOUT_SCRIPT_H
 
 // C++ standard includes
+#include <cstring> // for std::memcpy()    / int2ssl::bit_cast<>
+#include <memory>  // for std::addressof() / int2ssl::bit_cast<>
 #include <vector>
 
 // int2ssl includes
@@ -124,5 +126,22 @@ private:
     CMapuint32_tToDefObject m_Definitions;
     std::vector<std::string> m_GlobalVarsNames;
 };
+
+namespace int2ssl
+{
+    // https://en.cppreference.com/w/cpp/numeric/bit_cast
+    template<class T, class F>
+    T bit_cast(const F& f)
+    {
+        static_assert(sizeof(T) == sizeof(F), "Types must match sizes");
+        static_assert(std::is_pod<F>::value, "Requires POD input");
+        static_assert(std::is_pod<T>::value, "Requires POD output");
+
+        T t;
+        std::memcpy(std::addressof(t), std::addressof(f), sizeof(T));
+
+        return t;
+    }
+}
 
 #endif //FALLOUT_SCRIPT_H

--- a/FalloutScriptDump.cpp
+++ b/FalloutScriptDump.cpp
@@ -73,7 +73,7 @@ void CFalloutScript::Dump()
                                     i,
                                     m_GlobalVar[i].GetAttributes().m_strMnemonic.c_str(),
                                     ulArgument,
-                                    *((float*)(&ulArgument))) << std::endl;
+                                    int2ssl::bit_cast<float>(ulArgument)) << std::endl;
             }
         }
     }
@@ -113,7 +113,7 @@ void CFalloutScript::Dump()
                 case COpcode::O_FLOATOP:
                     g_ofstream << format("%s := %05f",
                                     m_Namespace[ulNameArgument].c_str(),
-                                    *((float*)(&ulArgument))) << std::endl;
+                                    int2ssl::bit_cast<float>(ulArgument)) << std::endl;
             }
         }
     }
@@ -156,7 +156,7 @@ void CFalloutScript::Dump()
                                       wOperator,
                                       ulArgument,
                                       m_ProcBodies[nIndexOfProc][i].m_Opcode.GetAttributes().m_strMnemonic.c_str(),
-                                      *((float*)(&ulArgument))) << std::endl;
+                                      int2ssl::bit_cast<float>(ulArgument)) << std::endl;
                     break;
 
                 default:

--- a/FalloutScriptStore.cpp
+++ b/FalloutScriptStore.cpp
@@ -104,7 +104,7 @@ void CFalloutScript::StoreDefinitions()
                     break;
 
                 case COpcode::O_FLOATOP:
-                    strDefinition = format(strDefinition + " := %.5f", *((float*)(&ulVarValue)));
+                    strDefinition = format(strDefinition + " := %.5f", int2ssl::bit_cast<float>(ulVarValue));
                     break;
 
                 case COpcode::O_INTOP:
@@ -249,7 +249,7 @@ void CFalloutScript::StoreDefinitions()
                                 break;
 
                             case COpcode::O_FLOATOP:
-                                strDefinition = format(strDefinition + " := %.5f", *((float*)(&defObject.m_ulVarValue)));
+                                strDefinition = format(strDefinition + " := %.5f", int2ssl::bit_cast<float>(defObject.m_ulVarValue));
                                 break;
 
                             case COpcode::O_INTOP:
@@ -548,7 +548,7 @@ std::string CFalloutScript::GetSource(CNode& node, bool bLabel, uint32_t ulNumAr
             break;
 
         case COpcode::O_FLOATOP:
-            strResult = format("%.5f", *((float*)(&ulArgument)));
+            strResult = format("%.5f", int2ssl::bit_cast<float>(ulArgument));
             break;
 
         case COpcode::O_INTOP:


### PR DESCRIPTION
Fixed gcc warning -Wstrict-aliasing (happens if using modern CMakeLists and specific configuration) with custom [std::bit_cast](https://en.cppreference.com/w/cpp/numeric/bit_cast). As side-effect, related code doesn't look like something from the bottom of garbage bin anymore.



Tested against ReDefine.Examples content, no changes in .ssl
